### PR TITLE
Fix for *.coffee spec files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.5
-  - 2.2.0
-  - ruby-head
-  - jruby
-  - rbx-2
+  - 2.2.6
+  - 2.3.3
 gemfile:
   - Gemfile
-matrix:
-  allow_failures:
-    - rvm: rbx-2
 # Use the faster container based infrastructure.
 sudo: false

--- a/lib/guard/konacha-rails/runner.rb
+++ b/lib/guard/konacha-rails/runner.rb
@@ -37,6 +37,7 @@ module Guard
 
         paths.each do |path|
           if path.empty? or File.exists? real_path path
+            UI.info "Guard::KonachaRails running #{specs_description(path)}"
             runner.run konacha_path(path)
           end
         end
@@ -66,6 +67,10 @@ module Guard
         end
       end
 
+      def specs_description(path)
+        path.empty? ? "all specs" : path
+      end
+
       def runner
         ::Konacha::Runner.new(@session)
       end
@@ -75,7 +80,15 @@ module Guard
       end
 
       def real_path(path)
-        ::Rails.root.join(::Konacha.config[:spec_dir] + konacha_path(path) + (path[/\.js(\.coffee)?$/] || '')).to_s
+        path.empty? ? all_specs_path : specific_path(path)
+      end
+
+      def all_specs_path
+        "#{::Rails.root.join(::Konacha.config[:spec_dir])}#{konacha_path('')}"
+      end
+
+      def specific_path(path)
+        ::Rails.root.join(path).to_s
       end
 
       def unique_id


### PR DESCRIPTION
This fix ensures that spec files which have a suffix of `.coffee` rather than `.js.coffee` will be detected when they change. Also, a helpful UI info message is displayed just before a spec or specs are run.